### PR TITLE
Feature/http 11 parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,14 @@ This feature adds IPv4 socket configuration using Linux kernel functions:
 - sys/socket.h::accept() to accept incoming client connections
 sudo lsof -n -i :80 | grep LISTEN
 main    3465 patrickmanacorda    3u  IPv4 0xafe05602b6b5b277      0t0  TCP *:http (LISTEN)
+
+# Add-HTTP1.1-Parser
+This feature reads and parses HTTP1.1 raw input bytes from the client socket:
+- sys/socket.h::read() to get bytes from socket descriptor into a temporary buffer
+- continue reading until header termination `\r\n\r\n` is received
+- built-in protections against oversized headers (8KB limit)
+- parse first line which reveals method, path, query parameters and HTTP version
+- parse headers after first line until termination sequence as Key:Value pairs
+- if Content-Length is present continue reading from socket until body length matches expected bytes
+- supports GET, POST, and DELETE methods with proper error handling
+- custom HttpRequest structure stores the parsed result with method, path, headers, parameters, and body

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,171 @@
 #include <errno.h>
 #include <netinet/in.h>
 #include <cstring>
+#include <unistd.h>
+#include <sstream>
+#include <vector>
+#include <string>
+#include <unordered_map>
+
+/*
+    See HTTP1.1 Message Syntax: https://datatracker.ietf.org/doc/html/rfc7230#section-3
+    "...The normal procedure for parsing an HTTP message is to read the
+    start-line into a structure, read each header field into a hash table
+    by field name until the empty line, and then use the parsed data to
+    determine if a message body is expected.  If a message body has been
+    indicated, then it is read as a stream until an amount of octets
+    equal to the message body length is read or the connection is closed."
+*/
+enum HttpMethod{
+    GET,
+    POST,
+    DELETE
+};
+struct HttpRequest{
+    HttpMethod method = GET;
+    std::string path;
+    std::string body;
+    std::unordered_map<std::string,std::string> headers;
+    std::unordered_map<std::string,std::string> parameters;
+    HttpRequest() : method(GET), path(""), body("") {}
+};
+HttpRequest recv(int clientSocket) {
+    HttpRequest httpRequest;
+    std::string http11 = "HTTP/1.1";
+    char buffer[4096];
+    std::string raw;
+    ssize_t result;
+    std::string termination = "\r\n\r\n";
+
+    // Read until header termination
+    while (raw.find(termination) == std::string::npos) {
+        result = read(clientSocket, buffer, sizeof(buffer));
+        if (result == -1) {
+            std::cerr << "ERROR - socket read failed: " << strerror(errno) << std::endl;
+            return httpRequest;
+        }
+        if (result == 0) { 
+            std::cerr << "ERROR - connection closed unexpectedly" << std::endl;
+            return httpRequest;
+        }
+        raw.append(buffer, result);
+        if (raw.size() > 8192) {
+            std::cerr << "ERROR - headers too large\n";
+            return httpRequest;
+        }
+    }
+    // Parse Start Line: method and path
+    size_t startLineEnd = raw.find("\r\n");
+    if(startLineEnd == std::string::npos){
+        std::cerr << "ERROR - Invalid HTTP format: no start line terminator" << std::endl;
+        return httpRequest;
+    }
+    std::string startLine = raw.substr(0, startLineEnd);
+    std::stringstream startLineStream(startLine);
+    std::string method, path, version;
+    if (!(startLineStream >> method >> path >> version)) {
+        std::cerr << "ERROR - Invalid start line format" << std::endl;
+        return httpRequest;
+    }
+    if (method == "GET") {
+        httpRequest.method = GET;
+    } else if (method == "POST") {
+        httpRequest.method = POST;
+    } else if (method == "DELETE") {
+        httpRequest.method = DELETE;
+    } else {
+        std::cerr << "ERROR - Unsupported HTTP method: " << method << std::endl;
+        return httpRequest;
+    }
+    httpRequest.path = path;
+    
+    // Parse query parameters
+    size_t queryParamIndex = httpRequest.path.find("?");
+    if(queryParamIndex != std::string::npos){
+        httpRequest.parameters = std::unordered_map<std::string,std::string>();
+        std::string temp = httpRequest.path;
+        httpRequest.path = temp.substr(0, queryParamIndex);
+        std::string queryParamsSegment = temp.substr(queryParamIndex+1);
+        std::stringstream ss(queryParamsSegment);
+        std::string token;
+        while(std::getline(ss, token, '&')){
+            size_t eqPos = token.find('=');
+            if (eqPos != std::string::npos) {
+                std::string key = token.substr(0, eqPos);
+                std::string value = token.substr(eqPos + 1);
+                httpRequest.parameters.insert_or_assign(key, value);
+            }
+        }
+    }
+
+    // Parse Headers
+    size_t headerStart = startLineEnd + 2;
+    size_t headersEnd = raw.find(termination);
+    std::string headerSection = raw.substr(headerStart, headersEnd - headerStart);
+    std::stringstream ss(headerSection);
+    std::string line;
+    httpRequest.headers = std::unordered_map<std::string,std::string>();
+    while(std::getline(ss, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+        size_t colonPos = line.find(':');
+        if (colonPos != std::string::npos) {
+            std::string key = line.substr(0, colonPos);
+            std::string value = line.substr(colonPos + 2);
+            httpRequest.headers.insert_or_assign(key, value);
+        }
+    }
+
+    // Read Full Content-Length Body
+    size_t bodyStart = headersEnd + termination.size();
+    std::string body = raw.substr(bodyStart);
+    if (httpRequest.headers.find("Content-Length") != httpRequest.headers.end()) {
+        int expectedSize = 0;
+        try{
+            expectedSize = std::stoi(httpRequest.headers["Content-Length"]);
+        }catch(const std::exception& e){
+            std::cout << "ERROR - Content-Length parsing error " << e.what() << std::endl;
+            return httpRequest;
+        }
+        while (body.size() < expectedSize) {
+            result = read(clientSocket, buffer, sizeof(buffer));
+            if (result == -1) {
+                std::cerr << "ERROR - socket read failed: " << strerror(errno) << std::endl;
+                return httpRequest;
+            }
+            if (result == 0) { 
+                std::cerr << "ERROR - connection closed unexpectedly" << std::endl;
+                return httpRequest;
+            }
+            raw.append(buffer, result);
+            body = raw.substr(bodyStart);
+        }
+        body = body.substr(0, expectedSize);
+    }
+
+    std::cout << "INFO - successfully read full request" << std::endl;
+    
+    httpRequest.body = body;
+    return httpRequest;
+}
+
+void handle(int clientSocket){
+    try{
+        // receive content stream
+        HttpRequest request = recv(clientSocket);
+
+        // write ack back
+        // see docs: https://man7.org/linux/man-pages/man2/write.2.html
+        std::string response = "HTTP/1.1 200 OK\r\nContent-Length: 3\r\n\r\nACK";
+        write(clientSocket, response.c_str(), response.size());
+    }catch(const std::exception& e){
+        std::cout << "ERROR - " << e.what() << std::endl;
+    }
+
+    // Close Connection
+    close(clientSocket);
+}
 
 int main(){
     std::cout << "INFO - Starting..." << std::endl;
@@ -16,7 +181,7 @@ int main(){
     int socketFileDescriptor = socket(ipv4domain, tcpConnections, singleProtocol);
     if (socketFileDescriptor == -1){
         std::cerr << "FATAL - socket creation failed " << strerror(errno) << std::endl;
-        exit(-1);
+        exit(1);
     }
     // set socket options
     // see docs: https://man7.org/linux/man-pages/man7/socket.7.html
@@ -58,6 +223,7 @@ int main(){
             continue;
         }
         std::cout << "CONNECTION RECEIVED WITH SOCKET " << clientSocket << std::endl;
+        handle(clientSocket);
     }
     return 1;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -209,7 +209,7 @@ int main(){
     int listenResult = listen(socketFileDescriptor, backlogConnectionQueue);
     if (listenResult == -1){
         std::cerr << "FATAL - socket listening failed " << strerror(errno) << std::endl;
-        exit(1);
+        exit(-1);
     }
     
     // accept incoming client connections


### PR DESCRIPTION
# Add-HTTP1.1-Parser
This feature reads and parses HTTP1.1 raw input bytes from the client socket:
- sys/socket.h::read() to get bytes from socket descriptor into a temporary buffer
- continue reading until header termination `\r\n\r\n` is received
- built-in protections against oversized headers (8KB limit)
- parse first line which reveals method, path, query parameters and HTTP version
- parse headers after first line until termination sequence as Key:Value pairs
- if Content-Length is present continue reading from socket until body length matches expected bytes
- supports GET, POST, and DELETE methods with proper error handling
- custom HttpRequest structure stores the parsed result with method, path, headers, parameters, and body