### PR TITLE
feature/add-flat-json-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ This feature reads and parses HTTP1.1 raw input bytes from the client socket:
 - if Content-Length is present continue reading from socket until body length matches expected bytes
 - supports GET, POST, and DELETE methods with proper error handling
 - custom HttpRequest structure stores the parsed result with method, path, headers, parameters, and body
+
+# Add-Flat-Json-Parser
+This feature adds parsing for flat JSON objects in HTTP request bodies:
+- parseJson() function processes JSON strings into key-value pairs
+- supports flat objects only: {"key": "value", "key2": 200, "key3": "value3"}
+- uses character-by-character parsing with switch statement for tokenization
+- automatically triggered when Content-Type header is "application/json"
+- integrates seamlessly with existing HTTP parser for POST request bodies
+- lightweight implementation without external JSON library dependencies


### PR DESCRIPTION
# Add-Flat-Json-Parser
This feature adds parsing for flat JSON objects in HTTP request bodies:
- parseJson() function processes JSON strings into key-value pairs
- supports flat objects only: {"key": "value", "key2": 200, "key3": "value3"}
- uses character-by-character parsing with switch statement for tokenization
- automatically triggered when Content-Type header is "application/json"
- integrates seamlessly with existing HTTP parser for POST request bodies
- lightweight implementation without external JSON library dependencies