### PR TITLE
feature: add SSL to existing socket connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,15 @@ This feature registers request handlers for matching HTTP paths:
 - controller functions populate the response directly with content and status
 - after execution, the HttpResponse is serialized and sent back to the client in JSON format
 - supports easy extension by adding new routes and handler logic
+
+# Add-SSL
+This feature adds HTTPS support using OpenSSL TLS:
+Generate self-signed cert and key with
+openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt -days 365 -nodes
+- Initializes SSL context with TLS_server_method()
+- Loads cert and private key into context
+- Disables insecure TLS/SSL versions and sets secure cipher list
+- Performs TLS handshake on client accept
+- Uses SSL_read/SSL_write to handle encrypted communication
+- Cleans up SSL objects on socket close
+

--- a/main.cpp
+++ b/main.cpp
@@ -33,7 +33,7 @@ void handle(Core::ClientSocket& clientSocket){
 }
 
 int main(){
-    Core::WebSocket listener(8080, 10);
+    Core::WebSocket listener(443, 10);
     while(true){
         try{
             Core::ClientSocket csocket = listener.accept();

--- a/src/core/headers/SocketModule.h
+++ b/src/core/headers/SocketModule.h
@@ -7,14 +7,19 @@
 #include "HttpModule.h"
 #include "PresentationModule.h"
 #include <sstream>
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
 
 namespace Core {
         class ClientSocket{
         private:
         int fd;
+        SSL* ssl;
+        void configureSSL(SSL_CTX*);
 
         public:
-        ClientSocket(int);
+        ClientSocket(int, SSL_CTX*);
         ~ClientSocket();
 
         ClientSocket(const ClientSocket&) = delete;
@@ -33,6 +38,8 @@ namespace Core {
         void configure();
         void bind();
         void listen();
+        void configureSSL();
+        SSL_CTX *ssl_ctx;
 
         public:
         WebSocket(int,int);


### PR DESCRIPTION
# Add-SSL
This feature adds HTTPS support using OpenSSL TLS:
Generate self-signed cert and key with
openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt -days 365 -nodes
- Initializes SSL context with TLS_server_method()
- Loads cert and private key into context
- Disables insecure TLS/SSL versions and sets secure cipher list
- Performs TLS handshake on client accept
- Uses SSL_read/SSL_write to handle encrypted communication
- Cleans up SSL objects on socket close